### PR TITLE
Updated to fix segv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ OCCLIBS=-lTKBRep -lTKG2d -lTKG3d -lTKGeomBase \
 ifeq "$(OCEINCLUDE)" ""
 
 #CXX=gcc-4.4
-CXXFLAGS += -I/usr/include/opencascade
-LDFLAGS += -L/usr/lib/opencas -L/usr/lib ${OCCLIBS}
+CXXFLAGS += -I/usr/local/Cellar/opencascade/7.3.0p3/include/opencascade
+LDFLAGS += -L/usr/local/Cellar/opencascade/7.3.0p3/lib -L/usr/lib ${OCCLIBS}
 
 else
 
@@ -33,7 +33,8 @@ endif
 #ifeq (Ubuntu,$(findstring Ubuntu,$(UNAME)))
 #UBUNTUDISTRO := $(shell lsb_release -c)
 #ifeq (oneiric,$(findstring oneiric,$(UBUNTUDISTRO)))
-CXX=g++-4.9
+#CXX=g++-4.9
+CXX=clang++ -std=c++11 -stdlib=libc++
 #endif
 #endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 UNAME := $(shell uname -a)
 OCEINCLUDE := $(shell if test -d /usr/local/include/oce; then echo "/usr/local/include/oce"; else echo ""; fi)
 
+OPENCASCADEINC?=/usr/include/opencascade
+OPENCASCADELIB?=/usr/lib/opencas
+
+$(info Using OPENCASCADEINC as "${OPENCASCADEINC}")
+$(info Using OPENCASCADELIB as "${OPENCASCADELIB}")
+
 OCCLIBS=-lTKBRep -lTKG2d -lTKG3d -lTKGeomBase \
 -lTKMath -lTKMesh -lTKSTEP -lTKSTEP209 \
 -lTKSTEPAttr -lTKSTEPBase -lTKSTL -lTKXSBase -lTKernel \
@@ -8,8 +14,8 @@ OCCLIBS=-lTKBRep -lTKG2d -lTKG3d -lTKGeomBase \
 ifeq "$(OCEINCLUDE)" ""
 
 #CXX=gcc-4.4
-CXXFLAGS += -I/usr/local/Cellar/opencascade/7.3.0p3/include/opencascade
-LDFLAGS += -L/usr/local/Cellar/opencascade/7.3.0p3/lib -L/usr/lib ${OCCLIBS}
+CXXFLAGS += -I$(OPENCASCADEINC)
+LDFLAGS += -L$(OPENCASCADELIB) -L/usr/lib ${OCCLIBS}
 
 else
 

--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,9 @@
 #include <TopoDS_Shape.hxx>
 // STL Read & Write Methods
 #include <StlAPI_Writer.hxx>
+#include <BRepMesh_IncrementalMesh.hxx>
+
+#include <iostream>
 
 int step2stl(char *in, char *out) {
 
@@ -16,15 +19,24 @@ int step2stl(char *in, char *out) {
 
   // Write to STL
   StlAPI_Writer stlWriter = StlAPI_Writer();
-  // stlWriter.SetCoefficient(0.0001);
+  //stlWriter.SetCoefficient(0.0001);
   stlWriter.ASCIIMode() = Standard_False;
+
+  BRepMesh_IncrementalMesh Mesh( Original_Solid, 0.01 );
+
+  Mesh.Perform();
+
   stlWriter.Write( Original_Solid, out);
 
-  return 1;
+  return 0;
 }
 
 
 Standard_Integer main (int argc, char *argv[]) {
-  step2stl(argv[1], argv[2]);
-  return 0;
+  if (argc != 3) {
+      std::cerr << "Usage: " << argv[0] << " file.step file.stl" << std::endl;
+      return 1;
+  }
+
+  return step2stl(argv[1], argv[2]);
 }


### PR DESCRIPTION
Actually, there are three changes in this one commit. These were all required to get the code working on macOS Mojave:

- Updated the Makefile to use clang; 
- Applied BRepMesh_IncrementalMesh transformation;
- Generate a simple usage message in the event that no arguments are given; 

There's also a change to the library location. There's probably a better way of configuring this (perhaps via an environment variable).